### PR TITLE
Update 10.md with new IBM links for at and anacron

### DIFF
--- a/10.md
+++ b/10.md
@@ -49,5 +49,7 @@ Use the links in the RESOURCES section to read up about how these timers work.
 
 * [A good overview of systemd/Timers](https://wiki.archlinux.org/index.php/Systemd/Timers)
 * ["How to Use Systemd Timers as a Cron Replacement"](https://www.maketecheasier.com/use-systemd-timers-as-cron-replacement/)
+* [Automate system administration tasks by scheduling jobs](https://developer.ibm.com/tutorials/l-lpic1-107-2/)
+* [Using cron to automate maintenance](https://developer.ibm.com/tutorials/au-usingcron/)
 
 *Copyright 2012-2021 @snori74 (Steve Brorens). Can be reused under the terms of the Creative Commons Attribution 4.0 International Licence (CC BY 4.0).*


### PR DESCRIPTION
I believe these links cover the topics that were originally referred to in previous, now defunct, IBM resource links. This also means the reference in the body of 10.md referring to resources on `at` and `anacron` is now accurate.