### PR TITLE
Fix directory path for `cd` to extracted nmap-7.70

### DIFF
--- a/17.md
+++ b/17.md
@@ -56,7 +56,7 @@ Remembering that directories have a leading "d" in the listing, you'll see that 
      -rw-r--r--  1 steve  steve  21633731    2011-10-01 06:46 nmap-7.70.tar.bz2
      drwxr-xr-x 20 steve  steve  4096        2011-10-01 06:06 nmap-7.70
 
-Now explore the contents of this with `mc` or simply `cd nmap.org/dist/nmap-7.70` - you should be able to use `ls` and `less` find and read the actual source code. Even if you know no programming, the comments can be entertaining reading.
+Now explore the contents of this with `mc` or simply `cd nmap-7.70` - you should be able to use `ls` and `less` find and read the actual source code. Even if you know no programming, the comments can be entertaining reading.
 
 By convention, source files will typically include in their root directory a series of text files in uppercase such as: README and INSTALLATION. Look for these, and read them using `more` or `less`. It's important to realise that the programmers of the "upstream" project are not writing for Ubuntu, CentOS  - or even Linux. They have written a correct working program in C or C++ etc and made it available, but it's up to us to figure out how to compile it for our operating system, chip type etc. (This hopefully gives a little insight into the value that distributions such as CentOS, Ubuntu and utilities such as `apt`, `yum` etc add, and how tough it would be to create your own Linux From Scratch)
 


### PR DESCRIPTION
From a perspective of $PWD, extracting previously downloaded archive file nmap-7.70.tar.bz2 in-place only creates "nmap-7.70" subdirectory (directly one level below), there's no "nmap.org/dist/nmap-7.70" directory structure.