### PR TITLE
Fix typos

### DIFF
--- a/docs/10.md
+++ b/docs/10.md
@@ -221,7 +221,7 @@ This is a more useful string that we can combine with our `tar` command to
 create an archive with today's date in it.
 
 ```bash
-vagrant@ubuntu2204:~$ sudo tar -czvf home.$(date -I).tar.gz /home/
+vagrant@ubuntu2204:~$ sudo tar -czvf /var/backups/home.$(date -I).tar.gz /home/
 tar: Removing leading `/' from member names
 /home/
 /home/ubuntu/

--- a/docs/15.md
+++ b/docs/15.md
@@ -81,7 +81,7 @@ Once done, you should be able to install `netperf` like this:
 Ubuntu also allows users to register an account and setup software in a Personal Package Archive (PPA) - typically these are setup by enthusiastic developers, and allow you to install the latest "cutting edge" software.
 
 As an example, install and run the `neofetch` utility. When run, this prints out a summary of your configuration and hardware.
-This is in the standard repositories, and `neofetch --version` will show the version. If for some reason you wanted to be have a later version you could install a developer's Neofetch PPA to your software sources by:
+This is in the standard repositories, and `neofetch --version` will show the version. If for some reason you wanted to have a later version you could install a developer's Neofetch PPA to your software sources by:
 
 `sudo add-apt-repository ppa:ubuntusway-dev/dev`
 

--- a/docs/17.md
+++ b/docs/17.md
@@ -86,7 +86,7 @@ In fact, this is fairly standard for many packages. Here's what each of the step
 
 Now, potentially this last step will have overwritten the `nmap` you already had, but more likely this new one has been installed into a different place.
 
-In general  _/bin_ is for key parts of the operating system,  _/usr/bin_ for less critical utilities and _/usr/local/bin_ for software you've chosed to manually install yourself. When you type a command it will search through each of the directories given in your PATH environment variable, and start the first match. So, if _/bin/nmap_ exists, it will run instead of _/usr/local/bin_ - but if you give the "full path" to the version you want - such as _/usr/local/bin/nmap_ - it will run that version instead.
+In general  _/bin_ is for key parts of the operating system,  _/usr/bin_ for less critical utilities and _/usr/local/bin_ for software you've chosen to manually install yourself. When you type a command it will search through each of the directories given in your PATH environment variable, and start the first match. So, if _/bin/nmap_ exists, it will run instead of _/usr/local/bin_ - but if you give the "full path" to the version you want - such as _/usr/local/bin/nmap_ - it will run that version instead.
 
 The “locate” command allows very fast searching for files, but because these files have only just been added, we'll need to manually update the index of files:
 
@@ -96,7 +96,7 @@ Then to search the index:
 
 `locate bin/nmap`
 
-This should find both your old and copies of `nmap`
+This should find both your old and new copies of `nmap`
 
 Now try running each, for example:
 
@@ -104,7 +104,7 @@ Now try running each, for example:
 
 `/usr/local/bin/nmap -V`
 
-The `nmap` utility relies on no other package or library, so is very easy to install from source. Most other packages have many "dependencies", so installing them from source by hand can be pretty challenging even when well explained (look at: <http://oss.oetiker.ch/smokeping/doc/smokeping_install.en.html> for a good example).
+The `nmap` utility relies on no other package or library, so it is very easy to install from source. Most other packages have many "dependencies", so installing them from source by hand can be pretty challenging even when well explained (look at: <http://oss.oetiker.ch/smokeping/doc/smokeping_install.en.html> for a good example).
 
 NOTE: Because you've done all this outside of the `apt` system, this binary won't get updates when you run `apt update`. Not a big issue with a utility like `nmap` probably, but for anything that runs as an exposed service it's important that you understand that you now have to track security alerts for the application (and all of its dependencies), and install the later fixed versions when they're available. This is a significant pain/risk for a production server.
 


### PR DESCRIPTION
- Day 10: Added the full path to the snippet where the tarball with the date is created, as the next code snippet expects both tarballs (with and without the date) to be in `/var/backups`.
- Day 15 and 17 - added/omitted/changed words where needed